### PR TITLE
Macroscope

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ _Don't be like Bob, use neoclip!_ 🎉
 It records everything that gets yanked in your vim session (up to a limit which is by default 1000 entries but can be configured).
 You can then select an entry in the history using [`telescope`](https://github.com/nvim-telescope/telescope.nvim) or [`fzf-lua`](https://github.com/ibhagwan/fzf-lua) which then gets populated in a register of your choice.
 
+If you're on latest nightly (works if `:echo exists('##RecordingLeave')` returns `1`) `neoclip` will also keep track of any recorded macro (opt-out) which you can search for using `telescope`, put back in a register or simply replay.
+
 That's it!
 
 Oh, some more things, you can define an optional filter if you don't want some things to be saved and custom actions to take.
@@ -75,8 +77,13 @@ use {
       filter = nil,
       preview = true,
       default_register = '"',
+      default_register_macros = 'q',
+      enable_macro_history = true,
       content_spec_column = false,
       on_paste = {
+        set_reg = false,
+      },
+      on_replay = {
         set_reg = false,
       },
       keys = {
@@ -85,12 +92,14 @@ use {
             select = '<cr>',
             paste = '<c-p>',
             paste_behind = '<c-k>',
+            replay = '<c-q>',
             custom = {},
           },
           n = {
             select = '<cr>',
             paste = 'p',
             paste_behind = 'P',
+            replay = 'q',
             custom = {},
           },
         },
@@ -118,12 +127,16 @@ use {
   Useful for for example multiline yanks.
   When yanking the filetype is recorded in order to enable correct syntax highlighting in the preview.
   NOTE: in order to use the dynamic title showing the type of content and number of lines you need to configure `telescope` with the `dynamic_preview_title = true` option.
-* `default_register`: What register to by default when not specifying (e.g. `Telescope neoclip`).
+* `default_register`: What register to use by default when not specified (e.g. `Telescope neoclip`).
   Can be a string such as `'"'` (single register) or a table of strings such as `{'"', '+', '*'}`.
+* `default_register_macros`: What register to use for macros by default when not specified (e.g. `Telescope macroscope`).
+* `enable_macro_history`: If `true` (default) any recorded macro will be saved, see [macros](#macros).
 * `content_spec_colunm`: Can be set to `true` (default `false`) to use instead of the preview.
   It will only show the type and number of lines next to the first line of the entry.
 * `on_paste`:
-  * `set_reg`: if the register when pressing the key to paste directly.
+  * `set_reg`: if the register should be populated when pressing the key to paste directly.
+* `on_replay`:
+  * `set_reg`: if the register should be populated when pressing the key to replay a recorded macro.
 * `keys`: keys to use for the different pickers (`telescope` and `fzf-lua`).
   With `telescope` normal key-syntax is supported and both insert `i` and normal mode `n`.
   With `fzf-lua` only insert mode is supported and `fzf`-style key-syntax needs to be used.
@@ -189,6 +202,7 @@ require('neoclip').setup({
 ```
 
 ## Usage
+### Yanks
 Yank all you want and then do:
 ```vim
 :Telescope neoclip
@@ -231,6 +245,19 @@ if using `telescope` or
 :lua require('neoclip.fzf')({'a', 'star', 'plus', 'b'})
 ```
 if using `fzf-lua`.
+
+### Macros
+If `enable_macro_history` is set to `true` (default) in the [`setup`](#configuration) then any recorded macro will be stored and can later be accessed using:
+```vim
+:Telescope macroscope
+```
+or equivalently (which is probably the better way if you're lazy loading `telescope`):
+```vim
+:lua require('telescope').extensions.macroscope.default()
+```
+The same arguments are supported as for the `neoclip` extension.
+
+NOTE: This feature requires latest nightly and in particular [this PR](https://github.com/neovim/neovim/pull/16684). You can check that your neovim supports this by checking that `:echo exists('##RecordingLeave')` returns `1`. If not then everything will work normally except that no macro will be saved in the history of `neoclip`.
 
 ### Start/stop
 If you temporarily don't want `neoclip` to record anything you can use the following calls:

--- a/doc/neoclip.txt
+++ b/doc/neoclip.txt
@@ -42,6 +42,11 @@ configured). You can then select an entry in the history using `telescope`
 <https://github.com/ibhagwan/fzf-lua> which then gets populated in a register
 of your choice.
 
+If you’re on latest nightly (works if `:echo exists('##RecordingLeave')`
+returns `1`) `neoclip` will also keep track of any recorded macro (opt-out)
+which you can search for using `telescope`, put back in a register or simply
+replay.
+
 That’s it!
 
 Oh, some more things, you can define an optional filter if you don’t want
@@ -111,8 +116,13 @@ The following are the defaults and the keys are explained below:
           filter = nil,
           preview = true,
           default_register = '"',
+          default_register_macros = 'q',
+          enable_macro_history = true,
           content_spec_column = false,
           on_paste = {
+            set_reg = false,
+          },
+          on_replay = {
             set_reg = false,
           },
           keys = {
@@ -121,12 +131,14 @@ The following are the defaults and the keys are explained below:
                 select = '<cr>',
                 paste = '<c-p>',
                 paste_behind = '<c-k>',
+                replay = '<c-q>',
                 custom = {},
               },
               n = {
                 select = '<cr>',
                 paste = 'p',
                 paste_behind = 'P',
+                replay = 'q',
                 custom = {},
               },
             },
@@ -157,12 +169,16 @@ The following are the defaults and the keys are explained below:
     Useful for for example multiline yanks.
     When yanking the filetype is recorded in order to enable correct syntax highlighting in the preview.
     NOTE: in order to use the dynamic title showing the type of content and number of lines you need to configure `telescope` with the `dynamic_preview_title = true` option.
-- `default_register`: What register to by default when not specifying (e.g. `Telescope neoclip`).
+- `default_register`: What register to use by default when not specified (e.g. `Telescope neoclip`).
     Can be a string such as `'"'` (single register) or a table of strings such as `{'"', '+', '*'}`.
+- `default_register_macros`: What register to use for macros by default when not specified (e.g. `Telescope macroscope`).
+- `enable_macro_history`: If `true` (default) any recorded macro will be saved, see |neoclip-macros|.
 - `content_spec_colunm`: Can be set to `true` (default `false`) to use instead of the preview.
     It will only show the type and number of lines next to the first line of the entry.
 - `on_paste`:
-    - `set_reg`: if the register when pressing the key to paste directly.
+    - `set_reg`: if the register should be populated when pressing the key to paste directly.
+- `on_replay`:
+    - `set_reg`: if the register should be populated when pressing the key to replay a recorded macro.
 - `keys`: keys to use for the different pickers (`telescope` and `fzf-lua`).
     With `telescope` normal key-syntax is supported and both insert `i` and normal mode `n`.
     With `fzf-lua` only insert mode is supported and `fzf`-style key-syntax needs to be used.
@@ -240,6 +256,8 @@ to do your custom action and also populate a register and/or paste you can call
 
 USAGE                                                          *neoclip-usage*
 
+YANKS ~
+
 Yank all you want and then do:
 
 >
@@ -303,6 +321,32 @@ if using `telescope` or
 
 
 if using `fzf-lua`.
+
+MACROS ~
+
+If `enable_macro_history` is set to `true` (default) in the |neoclip-`setup`|
+then any recorded macro will be stored and can later be accessed using:
+
+>
+    :Telescope macroscope
+<
+
+
+or equivalently (which is probably the better way if you’re lazy loading
+`telescope`):
+
+>
+    :lua require('telescope').extensions.macroscope.default()
+<
+
+
+The same arguments are supported as for the `neoclip` extension.
+
+NOTE: This feature requires latest nightly and in particular this PR
+<https://github.com/neovim/neovim/pull/16684>. You can check that your neovim
+supports this by checking that `:echo exists('##RecordingLeave')` returns `1`.
+If not then everything will work normally except that no macro will be saved in
+the history of `neoclip`.
 
 START/STOP ~
 

--- a/lua/neoclip.lua
+++ b/lua/neoclip.lua
@@ -5,13 +5,23 @@ local settings = require('neoclip.settings')
 M.stopped = false
 
 local function setup_auto_command()
-    vim.cmd([[
-        augroup neoclip
-            autocmd!
-            autocmd TextYankPost * :lua require("neoclip.handlers").handle_yank_post()
-            autocmd VimLeavePre * :lua require("neoclip.handlers").on_exit()
-        augroup end
-    ]])
+    local commands = {
+        'augroup neoclip',
+        'autocmd!',
+        'autocmd TextYankPost * :lua require("neoclip.handlers").handle_yank_post()',
+        'autocmd VimLeavePre * :lua require("neoclip.handlers").on_exit()',
+    }
+    if vim.fn.exists('#RecordingLeave') then
+        table.insert(
+            commands,
+            'autocmd RecordingLeave * :lua require("neoclip.handlers").handle_macro_post()'
+        )
+    end
+    table.insert(
+        commands,
+        'augroup end'
+    )
+    vim.cmd(table.concat(commands, '\n'))
 end
 
 M.stop = function()

--- a/lua/neoclip.lua
+++ b/lua/neoclip.lua
@@ -11,7 +11,7 @@ local function setup_auto_command()
         'autocmd TextYankPost * :lua require("neoclip.handlers").handle_yank_post()',
         'autocmd VimLeavePre * :lua require("neoclip.handlers").on_exit()',
     }
-    if vim.fn.exists('##RecordingLeave') and settings.enable_macro_history then
+    if vim.fn.exists('##RecordingLeave') and settings.get().enable_macro_history then
         table.insert(
             commands,
             'autocmd RecordingLeave * :lua require("neoclip.handlers").handle_macro_post()'

--- a/lua/neoclip.lua
+++ b/lua/neoclip.lua
@@ -11,7 +11,7 @@ local function setup_auto_command()
         'autocmd TextYankPost * :lua require("neoclip.handlers").handle_yank_post()',
         'autocmd VimLeavePre * :lua require("neoclip.handlers").on_exit()',
     }
-    if vim.fn.exists('#RecordingLeave') then
+    if vim.fn.exists('##RecordingLeave') and settings.enable_macro_history then
         table.insert(
             commands,
             'autocmd RecordingLeave * :lua require("neoclip.handlers").handle_macro_post()'

--- a/lua/neoclip/db.lua
+++ b/lua/neoclip/db.lua
@@ -54,7 +54,6 @@ M.get = function(query)
         local success, entries = pcall(tbl.get, tbl, query)
         if success then
             storage[key] = entries
-            return entries
         else
             warn(string.format("Couldn't load (%s) history since: %s", key, entries))
             return {}
@@ -70,10 +69,12 @@ M.update = function(storage)
             warn(string.format("Couldn't remove clear database since: %s", msg))
             return
         end
-        success, msg = pcall(tbl.insert, tbl, storage[key])
-        if not success then
-            warn(string.format("Couldn't insert in database since: %s", msg))
-            return
+        if #storage[key] > 0 then  -- Don't insert if empty since it causes an error for some reason
+            success, msg = pcall(tbl.insert, tbl, storage[key])
+            if not success then
+                warn(string.format("Couldn't insert in database since: %s", msg))
+                return
+            end
         end
     end
 end

--- a/lua/neoclip/db.lua
+++ b/lua/neoclip/db.lua
@@ -1,10 +1,11 @@
 local settings = require('neoclip.settings').get()
+local warn = require('neoclip.warn').warn
 
 local M = {}
 
 local has_sqlite, sqlite = pcall(require, "sqlite")
 if not has_sqlite then
-    print "Couldn't find sqlite.lua. Cannot use persistent history"
+    warn("Couldn't find sqlite.lua. Cannot use persistent history")
     return nil
 end
 
@@ -16,12 +17,12 @@ local function make_db_dir(db_path)
     os.execute('mkdir -p ' .. dirname(db_path))
 end
 
-local function get_tbl()
+local function get_tbl(name)
     local db_path = settings.db_path
     make_db_dir(db_path)
     local db = sqlite.new(db_path)
     db:open()
-    local tbl = db:tbl("neoclip", {
+    local tbl = db:tbl(name, {
         regtype = "text",
         contents = "luatable",
         filetype = "text",
@@ -30,7 +31,10 @@ local function get_tbl()
     return tbl
 end
 
-M.tbl = get_tbl()
+M.tables = {
+    yanks = get_tbl('neoclip'),
+    macros = get_tbl('macros'),
+}
 
 local function copy(t)
     local new = {}
@@ -45,23 +49,32 @@ local function copy(t)
 end
 
 M.get = function(query)
-    local success, entries = pcall(M.tbl.get, M.tbl, query)
-    if success then
-        return entries
-    else
-        print("Couldn't load history since:", entries)
-        return {}
+    local storage = {}
+    for key, tbl in pairs(M.tables) do
+        local success, entries = pcall(tbl.get, tbl, query)
+        if success then
+            storage[key] = entries
+            return entries
+        else
+            warn(string.format("Couldn't load (%s) history since: %s", key, entries))
+            return {}
+        end
     end
+    return storage
 end
 
 M.update = function(storage)
-    local success, msg = pcall(M.tbl.remove, M.tbl)
-    if not success then
-        print("Couldn't remove clear database since:", msg)
-    end
-    success, msg = pcall(M.tbl.insert, M.tbl, storage)
-    if not success then
-        print("Couldn't insert in database since:", msg)
+    for key, tbl in pairs(M.tables) do
+        local success, msg = pcall(tbl.remove, tbl)
+        if not success then
+            warn(string.format("Couldn't remove clear database since: %s", msg))
+            return
+        end
+        success, msg = pcall(tbl.insert, tbl, storage[key])
+        if not success then
+            warn(string.format("Couldn't insert in database since: %s", msg))
+            return
+        end
     end
 end
 

--- a/lua/neoclip/fzf.lua
+++ b/lua/neoclip/fzf.lua
@@ -1,5 +1,5 @@
 local handlers = require('neoclip.handlers')
-local storage = require('neoclip.storage').get()
+local storage = require('neoclip.storage').get().yanks
 local settings = require('neoclip.settings').get()
 local picker_utils = require('neoclip.picker_utils')
 

--- a/lua/neoclip/handlers.lua
+++ b/lua/neoclip/handlers.lua
@@ -41,17 +41,18 @@ M.handle_yank_post = function()
     end
 end
 
-M.handle_macro_post = function()
+M.handle_macro_post = vim.schedule_wrap(function()
     if neoclip.stopped then
         return
     end
-    local event = vim.v.event -- TODO update
+    local regname = vim.fn.reg_recorded()
+    local reginfo = vim.fn.getreginfo(regname)
     storage.insert({
-        regtype = get_regtype(event.regtype),
-        contents = event.regcontents,
+        regtype = get_regtype(reginfo.regtype),
+        contents = reginfo.regcontents,
         filetype = nil,
     }, 'macros')
-end
+end)
 
 M.on_exit = function()
     storage.on_exit()
@@ -67,14 +68,27 @@ M.set_registers = function(register_names, entry)
     end
 end
 
-M.paste = function(entry, op)
+local function temporary_reg_usage(entry, callback)
     local register_name = '"'
     local current_contents = vim.fn.getreg(register_name)
     local current_regtype = vim.fn.getregtype(register_name)
     set_register(register_name, entry)
-    -- TODO can this be done without setting the register
-    vim.cmd(string.format('normal! "%s%s', register_name, op))
+    callback(register_name)
     vim.fn.setreg(register_name, current_contents, current_regtype)
+end
+
+-- TODO can this be done without setting the register?
+M.paste = function(entry, op)
+    temporary_reg_usage(entry, function(register_name)
+        vim.cmd(string.format('normal! "%s%s', register_name, op))
+    end)
+end
+
+-- TODO can this be done without setting the register?
+M.replay = function(entry)
+    temporary_reg_usage(entry, function(register_name)
+        vim.cmd(string.format('normal! @%s', register_name))
+    end)
 end
 
 return M

--- a/lua/neoclip/handlers.lua
+++ b/lua/neoclip/handlers.lua
@@ -37,8 +37,20 @@ M.handle_yank_post = function()
             regtype = get_regtype(event.regtype),
             contents = event.regcontents,
             filetype = vim.bo.filetype,
-        })
+        }, 'yanks')
     end
+end
+
+M.handle_macro_post = function()
+    if neoclip.stopped then
+        return
+    end
+    local event = vim.v.event -- TODO update
+    storage.insert({
+        regtype = get_regtype(event.regtype),
+        contents = event.regcontents,
+        filetype = nil,
+    }, 'macros')
 end
 
 M.on_exit = function()

--- a/lua/neoclip/handlers.lua
+++ b/lua/neoclip/handlers.lua
@@ -41,18 +41,17 @@ M.handle_yank_post = function()
     end
 end
 
-M.handle_macro_post = vim.schedule_wrap(function()
+M.handle_macro_post = function()
     if neoclip.stopped then
         return
     end
-    local regname = vim.fn.reg_recorded()
-    local reginfo = vim.fn.getreginfo(regname)
+    local event = vim.v.event
     storage.insert({
-        regtype = get_regtype(reginfo.regtype),
-        contents = reginfo.regcontents,
+        regtype = 'c',
+        contents = {event.regcontents},
         filetype = nil,
     }, 'macros')
-end)
+end
 
 M.on_exit = function()
     storage.on_exit()

--- a/lua/neoclip/settings.lua
+++ b/lua/neoclip/settings.lua
@@ -7,6 +7,7 @@ local settings = {
     filter = nil,
     preview = true,
     default_register = '"',
+    default_register_macros = 'q',
     content_spec_column = false,
     on_paste = {
         set_reg = false,
@@ -17,12 +18,14 @@ local settings = {
                 select = '<cr>',
                 paste = '<c-p>',
                 paste_behind = '<c-k>',
+                run_macro = '<c-q>',
                 custom = {},
             },
             n = {
                 select = '<cr>',
                 paste = 'p',
                 paste_behind = 'P',
+                run_macro = 'q',
                 custom = {},
             },
         },

--- a/lua/neoclip/settings.lua
+++ b/lua/neoclip/settings.lua
@@ -8,8 +8,12 @@ local settings = {
     preview = true,
     default_register = '"',
     default_register_macros = 'q',
+    enable_macro_history = true,
     content_spec_column = false,
     on_paste = {
+        set_reg = false,
+    },
+    on_replay = {
         set_reg = false,
     },
     keys = {
@@ -18,14 +22,14 @@ local settings = {
                 select = '<cr>',
                 paste = '<c-p>',
                 paste_behind = '<c-k>',
-                run_macro = '<c-q>',
+                replay = '<c-q>',
                 custom = {},
             },
             n = {
                 select = '<cr>',
                 paste = 'p',
                 paste_behind = 'P',
-                run_macro = 'q',
+                replay = 'q',
                 custom = {},
             },
         },
@@ -49,7 +53,6 @@ end
 local function check_keys()
     local keys = settings.keys
     if keys.i ~= nil or keys.n ~= nil then
-        -- TODO check PR number
         warn('Using settings.keys without specifying \'telescope\' or \'fzf\' will not be supported in the future, see #29.')
         keys.telescope = keys
     end

--- a/lua/neoclip/storage.lua
+++ b/lua/neoclip/storage.lua
@@ -2,7 +2,10 @@ local M = {}
 
 local settings = require('neoclip.settings').get()
 
-local storage = {}
+local storage = {
+    yanks = {},
+    macros = {},
+}
 if settings.enable_persistant_history then
     storage = require('neoclip.db').get()
 end
@@ -11,16 +14,19 @@ M.get = function()
     return storage
 end
 
-M.insert = function(contents)
-    while #storage >= settings.history do
-        table.remove(storage, #storage)
+M.insert = function(contents, typ)
+    local entries = storage[typ]
+    while #entries >= settings.history do
+        table.remove(entries, #entries)
     end
-    table.insert(storage, 1, contents)
+    table.insert(entries, 1, contents)
 end
 
 M.clear = function()
-    while #storage > 0 do
-        table.remove(storage, 1)
+    for _, entries in pairs(storage) do
+        while #entries > 0 do
+            table.remove(entries, 1)
+        end
     end
 end
 

--- a/lua/neoclip/telescope.lua
+++ b/lua/neoclip/telescope.lua
@@ -1,0 +1,200 @@
+local M = {}
+
+local finders = require("telescope.finders")
+local pickers = require("telescope.pickers")
+local config = require("telescope.config").values
+local actions = require("telescope.actions")
+local action_state = require("telescope.actions.state")
+local entry_display = require "telescope.pickers.entry_display"
+local previewers = require('telescope.previewers')
+
+local handlers = require('neoclip.handlers')
+local storage = require('neoclip.storage').get()
+local settings = require('neoclip.settings').get()
+local utils = require('neoclip.utils')
+local picker_utils = require('neoclip.picker_utils')
+
+local function get_set_register_handler(register_names)
+    return function(prompt_bufnr)
+        local entry = action_state.get_selected_entry()
+        actions.close(prompt_bufnr)
+        handlers.set_registers(register_names, entry)
+    end
+end
+
+local function get_paste_handler(register_names, op)
+    return function(prompt_bufnr)
+        local entry = action_state.get_selected_entry()
+        -- TODO if we can know the bufnr "behind" telescope we wouldn't need to close
+        -- and have it optional
+        actions.close(prompt_bufnr)
+        if settings.on_paste.set_reg then
+            handlers.set_registers(register_names, entry)
+        end
+        handlers.paste(entry, op)
+    end
+end
+
+local function get_custom_action_handler(register_names, action)
+    return function(prompt_bufnr)
+        local entry = action_state.get_selected_entry()
+        actions.close(prompt_bufnr)
+        action({
+            register_names=register_names,
+            entry = {
+                contents=entry.contents,
+                filetype=entry.filetype,
+                regtype=entry.regtype,
+            }
+        })
+    end
+end
+
+local displayer = entry_display.create {
+    separator = " ",
+    items = {
+        { width = 60 },
+        { remaining = true },
+    },
+}
+
+local spec_per_regtype = {
+    c = 'charwise',
+    l = 'linewise',
+    b = 'blockwise',
+}
+
+local function spec_from_entry(entry)
+    local spec = spec_per_regtype[entry.regtype]
+    local num_lines = #entry.contents
+    if num_lines > 1 then
+        spec = string.format('%s (%d lines)', spec, num_lines)
+    end
+    return spec
+end
+
+local function make_display(entry)
+    local to_display = {entry.contents[1]}
+    if settings.content_spec_column then
+        table.insert(to_display, {spec_from_entry(entry), "Comment"})
+    end
+    return displayer(to_display)
+end
+
+local function entry_maker(entry)
+    return {
+        display = make_display,
+        contents = entry.contents,
+        regtype = entry.regtype,
+        filetype = entry.filetype,
+        ordinal = table.concat(entry.contents, '\n'),
+        -- TODO seem to be needed
+        name = 'name',
+        value = 'value', -- TODO what to put value to, affects sorting?
+    }
+end
+
+local special_registers = {
+    unnamed = '"',
+    star = '*',
+    plus = '+',
+}
+
+local function parse_extra(extra)
+    local registers = {}
+    for _, r in ipairs(vim.fn.split(extra, ',')) do
+        if special_registers[r] == nil then
+            table.insert(registers, r)
+        else
+            table.insert(registers, special_registers[r])
+        end
+    end
+    return registers
+end
+
+local function map_if_set(map, mode, key, handler)
+    if key ~= nil then
+        map(mode, key, handler)
+    end
+end
+
+local function get_export(register_names, typ)
+    if type(register_names) == 'string' then
+        register_names = {register_names}
+    end
+    return function(opts)
+        local previewer = false
+        if settings.preview then
+            previewer = previewers.new_buffer_previewer({
+                define_preview = function(self, entry, status)
+                    vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, true, entry.contents)
+                    vim.bo[self.state.bufnr].filetype = entry.filetype
+                end,
+                dyn_title = function(self, entry)
+                    return spec_from_entry(entry)
+                end
+            })
+        end
+        if opts ~= nil and opts.extra ~= nil then
+            register_names = utils.join(register_names, parse_extra(opts.extra))
+        end
+        pickers.new(opts, {
+            prompt_title = picker_utils.make_prompt_title(register_names),
+            finder = finders.new_table({
+                results = storage[typ],
+                entry_maker = entry_maker,
+            }),
+            previewer = previewer,
+            sorter = config.generic_sorter(opts),
+            attach_mappings = function(_, map)
+                for _, mode in ipairs({'i', 'n'}) do
+                    local keys = settings.keys.telescope[mode]
+                    map_if_set(map, mode, keys.select, get_set_register_handler(register_names))
+                    map_if_set(map, mode, keys.paste, get_paste_handler(register_names, 'p'))
+                    map_if_set(map, mode, keys.paste_behind, get_paste_handler(register_names, 'P'))
+                    if keys.custom ~= nil then
+                        for key, action in pairs(keys.custom) do
+                            map(mode, key, get_custom_action_handler(register_names, action))
+                        end
+                    end
+                end
+                return true
+            end,
+        }):find()
+    end
+end
+
+local function register_names()
+    local names = {}
+    for name, reg in pairs(special_registers) do
+        names[reg] = name
+    end
+    for i = 1, 9 do -- [0-9]
+        local reg = string.format('%d', i)
+        names[reg] = reg
+    end
+    for c = 97, 122 do -- [a-z]
+        local reg = string.char(c)
+        names[reg] = reg
+    end
+    return names
+end
+
+M.get_exports = function(typ)
+    local exports = {}
+    for reg, name in pairs(register_names()) do
+        local export = get_export(reg)
+        exports[name] = export
+    end
+    if typ == 'macros' then
+        register_names = settings.default_register_macros
+    else
+        register_names = settings.default_register
+    end
+    local default = get_export(register_names, typ)
+    exports['default'] = default
+    exports['neoclip'] = default
+    return exports
+end
+
+return M

--- a/lua/neoclip/warn.lua
+++ b/lua/neoclip/warn.lua
@@ -1,0 +1,8 @@
+local M = {}
+
+M.warn = function(msg)
+    msg = vim.fn.escape(msg, '"')
+    vim.cmd(string.format('echohl WarningMsg | echo "Warning: %s" | echohl None', msg))
+end
+
+return M

--- a/lua/neoclip/warn.lua
+++ b/lua/neoclip/warn.lua
@@ -2,7 +2,7 @@ local M = {}
 
 M.warn = function(msg)
     msg = vim.fn.escape(msg, '"')
-    vim.cmd(string.format('echohl WarningMsg | echo "Warning: %s" | echohl None', msg))
+    vim.cmd(string.format('echohl WarningMsg | echomsg "Warning: %s" | echohl None', msg))
 end
 
 return M

--- a/lua/telescope/_extensions/macroscope.lua
+++ b/lua/telescope/_extensions/macroscope.lua
@@ -2,5 +2,5 @@ local telescope = require("telescope")
 local get_exports = require("neoclip.telescope").get_exports
 
 return telescope.register_extension {
-    exports = get_exports('yanks'),
+    exports = get_exports('macros'),
 }


### PR DESCRIPTION
`neoclip` can now also keep track of recorded macros (opt-out) and be accessed with the `macroscope` extension:
```vim
:Telescope macroscope
```

requires [`RecordingLeave`](https://github.com/neovim/neovim/pull/16684) to work.