### PR TITLE
ci: better triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,10 @@ name: Tests
 
 on:
   push:
-    branches:
-      - main
   pull_request:
-    branches:
-      - main
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   appimage-ubuntu:


### PR DESCRIPTION
1. We don't need to restrict the branch to run CI.
2. `workflow_dispatch` enables us to manually trigger CI.
3. A daily scheduled run can catch dependencies' breaking changes.