### PR TITLE
Resolve #66 by allowing users to disable mappings by passing false

### DIFF
--- a/lua/neoclip/fzf.lua
+++ b/lua/neoclip/fzf.lua
@@ -55,7 +55,7 @@ local function make_actions(register_names)
         end
     end
     for key, _ in pairs(actions) do
-        if key == nil then
+        if not key then
             actions[key] = nil
         end
     end

--- a/lua/neoclip/telescope.lua
+++ b/lua/neoclip/telescope.lua
@@ -135,7 +135,7 @@ local function parse_extra(extra)
 end
 
 local function map_if_set(map, mode, keys, desc, handler)
-    if keys == nil then
+    if not keys then
         return
     end
 


### PR DESCRIPTION
Hello, wanting to provide a fix for #66 that will allow users to disable mappings by passing false.

## Example
```lua
require(‘neoclip’).setup({
    keys = {
        telescope = {
            i = {
                paste = false — will restore telescope default <c-p> action to move to prev item
            }
        }
    }
})
```