### PR TITLE
fix(fzf-lua): use the newer 'fzf_exec' API

### DIFF
--- a/lua/neoclip/fzf.lua
+++ b/lua/neoclip/fzf.lua
@@ -110,21 +110,18 @@ local function neoclip(register_names)
         register_names = {register_names}
     end
     local actions = make_actions(register_names)
-    coroutine.wrap(function()
-        local selected = require('fzf-lua').fzf({
-            prompt = 'Prompt❯ ',
-            previewer = Previewer,
-            actions = actions,
-            fzf_opts = {
-                ["--header"] = vim.fn.shellescape(picker_utils.make_prompt_title(register_names)),
-                ["--delimiter"] = [[\\.]],
-                -- comment `--nth` if you want to enable
-                -- fuzzy matching the index number
-                ["--with-nth"] = '2..',
-            },
-        }, fn)
-        require('fzf-lua').actions.act(actions, selected, {})
-    end)()
+    require('fzf-lua').fzf_exec(fn, {
+      prompt = 'Prompt❯ ',
+      previewer = Previewer,
+      actions = actions,
+      fzf_opts = {
+        ["--header"] = vim.fn.shellescape(picker_utils.make_prompt_title(register_names)),
+        ["--delimiter"] = [[\\.]],
+        -- comment `--nth` if you want to enable
+        -- fuzzy matching the index number
+        ["--with-nth"] = '2..',
+      },
+    })
 end
 
 return neoclip


### PR DESCRIPTION
This makes fzf-lua work again with neoclip, using the new API also supports using `:FzfLua resume` to respawn fzf-lua's neoclip UI.