### PR TITLE
feat(fzf-lua): option to override fzf-lua picker opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ use {
       db_path = vim.fn.stdpath("data") .. "/databases/neoclip.sqlite3",
       filter = nil,
       preview = true,
+      prompt = nil,
       default_register = '"',
       default_register_macros = 'q',
       enable_macro_history = true,

--- a/lua/neoclip/fzf.lua
+++ b/lua/neoclip/fzf.lua
@@ -114,7 +114,7 @@ local function neoclip(register_names)
     end
     local actions = make_actions(register_names)
     require('fzf-lua').fzf_exec(fn, {
-      prompt = 'Prompt❯ ',
+      prompt = settings.prompt and settings.prompt or 'Prompt❯ ',
       previewer = Previewer,
       actions = actions,
       fzf_opts = {

--- a/lua/neoclip/fzf.lua
+++ b/lua/neoclip/fzf.lua
@@ -114,7 +114,7 @@ local function neoclip(register_names)
     end
     local actions = make_actions(register_names)
     require('fzf-lua').fzf_exec(fn, {
-      prompt = settings.prompt and settings.prompt or 'Prompt❯ ',
+      prompt = settings.prompt or 'Prompt❯ ',
       previewer = Previewer,
       actions = actions,
       fzf_opts = {

--- a/lua/neoclip/telescope.lua
+++ b/lua/neoclip/telescope.lua
@@ -177,6 +177,7 @@ local function get_export(register_names, typ)
         local results = storage.get({reversed = true})[typ]
         pickers.new(opts, {
             prompt_title = picker_utils.make_prompt_title(register_names),
+            prompt_prefix = settings.prompt or nil,
             finder = finders.new_table({
                 results = results,
                 entry_maker = entry_maker,


### PR DESCRIPTION
This change addresses issue #83. Now one can setup neoclip and override the prompt variable, for example, with the following configuration:

```lua
require('neoclip').setup {
    keys = {
        fzf = {
            opts = {
                prompt = 'clip> '
            }
        }
    }
}
```