### PR TITLE
feat: when using telescope/fzf, add option to set the selected entry as most recent

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ use {
       default_register_macros = 'q',
       enable_macro_history = true,
       content_spec_column = false,
+      refresh_entry_on_select = false,
       on_paste = {
         set_reg = false,
       },
@@ -146,6 +147,7 @@ use {
 * `enable_macro_history`: If `true` (default) any recorded macro will be saved, see [macros](#macros).
 * `content_spec_colunm`: Can be set to `true` (default `false`) to use instead of the preview.
   It will only show the type and number of lines next to the first line of the entry.
+* `refresh_entry_on_select`: When selecting an entry via telescope or fzf, move the selection to the bottom.
 * `on_paste`:
   * `set_reg`: if the register should be populated when pressing the key to paste directly.
 * `on_replay`:

--- a/README.md
+++ b/README.md
@@ -83,12 +83,16 @@ use {
       default_register_macros = 'q',
       enable_macro_history = true,
       content_spec_column = false,
-      refresh_entry_on_select = false,
+      on_select = {
+        move_to_front = false,
+      },
       on_paste = {
         set_reg = false,
+        move_to_front = false,
       },
       on_replay = {
         set_reg = false,
+        move_to_front = false,
       },
       keys = {
         telescope = {
@@ -145,13 +149,16 @@ use {
   Can be a string such as `'"'` (single register) or a table of strings such as `{'"', '+', '*'}`.
 * `default_register_macros`: What register to use for macros by default when not specified (e.g. `Telescope macroscope`).
 * `enable_macro_history`: If `true` (default) any recorded macro will be saved, see [macros](#macros).
-* `content_spec_colunm`: Can be set to `true` (default `false`) to use instead of the preview.
+* `content_spec_column`: Can be set to `true` (default `false`) to use instead of the preview.
   It will only show the type and number of lines next to the first line of the entry.
-* `refresh_entry_on_select`: When selecting an entry via telescope or fzf, move the selection to the bottom.
+* `on_select`:
+  * `move_to_front`: if the entry should be set as the lastest in the list when pressing the key to select a yank.
 * `on_paste`:
   * `set_reg`: if the register should be populated when pressing the key to paste directly.
+  * `move_to_front`: if the entry should be set as the lastest in the list when pressing the key to paste directly.
 * `on_replay`:
   * `set_reg`: if the register should be populated when pressing the key to replay a recorded macro.
+  * `move_to_front`: if the entry should be set as the lastest in the list when pressing the key to replay a recorded macro.
 * `keys`: keys to use for the different pickers (`telescope` and `fzf-lua`).
   With `telescope` normal key-syntax is supported and both insert `i` and normal mode `n`.
   With `fzf-lua` only insert mode is supported and `fzf`-style key-syntax needs to be used.

--- a/lua/neoclip/fzf.lua
+++ b/lua/neoclip/fzf.lua
@@ -6,7 +6,6 @@ local storage = require('neoclip.storage')
 -- This needs to be filled dynamically with each call (#80)
 local _storage = nil
 
-
 local function get_idx(item)
     return tonumber(item:match("^%d+%."))
 end

--- a/lua/neoclip/fzf.lua
+++ b/lua/neoclip/fzf.lua
@@ -34,11 +34,11 @@ end
 local function get_paste_handler(register_names, op)
     return function(selected, _)
         local entry = parse_entry(selected[1])
+        handlers.paste(entry, op)
         if settings.on_paste.set_reg then
             handlers.set_registers(register_names, entry)
+            refresh_entry_if_needed(entry)
         end
-        handlers.paste(entry, op)
-        refresh_entry_if_needed(entry)
     end
 end
 

--- a/lua/neoclip/fzf.lua
+++ b/lua/neoclip/fzf.lua
@@ -6,11 +6,6 @@ local storage = require('neoclip.storage')
 -- This needs to be filled dynamically with each call (#80)
 local _storage = nil
 
-local function refresh_entry_if_needed (entry)
-    if settings.refresh_entry_on_select then
-        storage.set_as_most_recent('yanks', entry)
-    end
-end
 
 local function get_idx(item)
     return tonumber(item:match("^%d+%."))
@@ -26,17 +21,21 @@ local function get_set_register_handler(register_names)
     return function(selected, _)
         local entry = parse_entry(selected[1])
         handlers.set_registers(register_names, entry)
-        refresh_entry_if_needed(entry)
+        if settings.on_select.move_to_front then
+            storage.set_as_most_recent('yanks', entry)
+        end
     end
 end
 
 local function get_paste_handler(register_names, op)
     return function(selected, _)
         local entry = parse_entry(selected[1])
-        handlers.paste(entry, op)
         if settings.on_paste.set_reg then
             handlers.set_registers(register_names, entry)
-            refresh_entry_if_needed(entry)
+        end
+        handlers.paste(entry, op)
+        if settings.on_paste.move_to_front then
+            storage.set_as_most_recent('yanks', entry)
         end
     end
 end

--- a/lua/neoclip/fzf.lua
+++ b/lua/neoclip/fzf.lua
@@ -37,8 +37,8 @@ local function get_paste_handler(register_names, op)
         if settings.on_paste.set_reg then
             handlers.set_registers(register_names, entry)
         end
-        refresh_entry_if_needed(entry)
         handlers.paste(entry, op)
+        refresh_entry_if_needed(entry)
     end
 end
 

--- a/lua/neoclip/fzf.lua
+++ b/lua/neoclip/fzf.lua
@@ -12,7 +12,6 @@ local function refresh_entry_if_needed (entry)
     end
 end
 
-
 local function get_idx(item)
     return tonumber(item:match("^%d+%."))
 end

--- a/lua/neoclip/fzf.lua
+++ b/lua/neoclip/fzf.lua
@@ -1,9 +1,17 @@
 local handlers = require('neoclip.handlers')
 local settings = require('neoclip.settings').get()
 local picker_utils = require('neoclip.picker_utils')
+local storage = require('neoclip.storage')
 
 -- This needs to be filled dynamically with each call (#80)
 local _storage = nil
+
+local function refresh_entry_if_needed (entry)
+    if settings.refresh_entry_on_select then
+        storage.set_as_most_recent('yanks', entry)
+    end
+end
+
 
 local function get_idx(item)
     return tonumber(item:match("^%d+%."))
@@ -17,7 +25,9 @@ end
 
 local function get_set_register_handler(register_names)
     return function(selected, _)
-        handlers.set_registers(register_names, parse_entry(selected[1]))
+        local entry = parse_entry(selected[1])
+        handlers.set_registers(register_names, entry)
+        refresh_entry_if_needed(entry)
     end
 end
 
@@ -27,6 +37,7 @@ local function get_paste_handler(register_names, op)
         if settings.on_paste.set_reg then
             handlers.set_registers(register_names, entry)
         end
+        refresh_entry_if_needed(entry)
         handlers.paste(entry, op)
     end
 end

--- a/lua/neoclip/settings.lua
+++ b/lua/neoclip/settings.lua
@@ -12,6 +12,7 @@ local settings = {
     default_register_macros = 'q',
     enable_macro_history = true,
     content_spec_column = false,
+    refresh_entry_on_select = false,
     on_paste = {
         set_reg = false,
     },

--- a/lua/neoclip/settings.lua
+++ b/lua/neoclip/settings.lua
@@ -12,12 +12,16 @@ local settings = {
     default_register_macros = 'q',
     enable_macro_history = true,
     content_spec_column = false,
-    refresh_entry_on_select = false,
+    on_select = {
+        move_to_front = false,
+    },
     on_paste = {
         set_reg = false,
+        move_to_front = false,
     },
     on_replay = {
         set_reg = false,
+        move_to_front = false,
     },
     keys = {
         telescope = {

--- a/lua/neoclip/storage.lua
+++ b/lua/neoclip/storage.lua
@@ -51,6 +51,11 @@ M.insert = function(contents, typ)
     post_change()
 end
 
+M.set_as_most_recent = function (typ, entry)
+    M.delete(typ, entry)
+    M.insert(entry, typ)
+end
+
 local clear = function()
     for _, entries in pairs(storage) do
         entries:clear()

--- a/lua/neoclip/telescope.lua
+++ b/lua/neoclip/telescope.lua
@@ -14,16 +14,14 @@ local settings = require('neoclip.settings').get()
 local utils = require('neoclip.utils')
 local picker_utils = require('neoclip.picker_utils')
 
-local function refresh_entry_if_needed (typ, telescope_entry)
-    if settings.refresh_entry_on_select then
-        storage.set_as_most_recent(
-            typ,
-            {
-                regtype = telescope_entry.regtype,
-                contents = telescope_entry.contents
-            }
-        )
-    end
+local function move_entry_to_front (typ, telescope_entry)
+    storage.set_as_most_recent(
+        typ,
+        {
+            regtype = telescope_entry.regtype,
+            contents = telescope_entry.contents
+        }
+    )
 end
 
 local function get_set_register_handler(register_names, typ)
@@ -31,7 +29,9 @@ local function get_set_register_handler(register_names, typ)
         local entry = action_state.get_selected_entry()
         actions.close(prompt_bufnr)
         handlers.set_registers(register_names, entry)
-        refresh_entry_if_needed(typ, entry)
+        if settings.on_select.move_to_front then
+            move_entry_to_front(typ, entry)
+        end
     end
 end
 
@@ -41,10 +41,12 @@ local function get_paste_handler(register_names, typ, op)
         -- TODO if we can know the bufnr "behind" telescope we wouldn't need to close
         -- and have it optional
         actions.close(prompt_bufnr)
-        handlers.paste(entry, op)
         if settings.on_paste.set_reg then
             handlers.set_registers(register_names, entry)
-            refresh_entry_if_needed(typ, entry)
+        end
+        handlers.paste(entry, op)
+        if settings.on_paste.move_to_front then
+            move_entry_to_front(typ, entry)
         end
     end
 end
@@ -55,10 +57,12 @@ local function get_replay_recording_handler(register_names, typ)
         -- TODO if we can know the bufnr "behind" telescope we wouldn't need to close
         -- and have it optional
         actions.close(prompt_bufnr)
-        handlers.replay(entry)
         if settings.on_replay.set_reg then
             handlers.set_registers(register_names, entry)
-            refresh_entry_if_needed(typ, entry)
+        end
+        handlers.replay(entry)
+        if settings.on_replay.move_to_front then
+            move_entry_to_front(typ, entry)
         end
     end
 end

--- a/lua/neoclip/telescope.lua
+++ b/lua/neoclip/telescope.lua
@@ -23,9 +23,9 @@ end
 local function get_set_register_handler(register_names, typ)
     return function(prompt_bufnr)
         local entry = action_state.get_selected_entry()
-        refresh_entry_if_needed(typ, entry.db_entry)
         actions.close(prompt_bufnr)
         handlers.set_registers(register_names, entry)
+        refresh_entry_if_needed(typ, entry.db_entry)
     end
 end
 
@@ -35,11 +35,11 @@ local function get_paste_handler(register_names, typ, op)
         -- TODO if we can know the bufnr "behind" telescope we wouldn't need to close
         -- and have it optional
         actions.close(prompt_bufnr)
-        refresh_entry_if_needed(typ, entry.db_entry)
         if settings.on_paste.set_reg then
             handlers.set_registers(register_names, entry)
         end
         handlers.paste(entry, op)
+        refresh_entry_if_needed(typ, entry.db_entry)
     end
 end
 
@@ -49,11 +49,11 @@ local function get_replay_recording_handler(register_names, typ)
         -- TODO if we can know the bufnr "behind" telescope we wouldn't need to close
         -- and have it optional
         actions.close(prompt_bufnr)
-        refresh_entry_if_needed(typ, entry.db_entry)
         if settings.on_replay.set_reg then
             handlers.set_registers(register_names, entry)
         end
         handlers.replay(entry)
+        refresh_entry_if_needed(typ, entry.db_entry)
     end
 end
 

--- a/lua/neoclip/telescope.lua
+++ b/lua/neoclip/telescope.lua
@@ -120,7 +120,7 @@ local function entry_maker(entry)
         regtype = entry.regtype,
         filetype = entry.filetype,
         ordinal = table.concat(entry.contents, '\n'),
-				db_entry = entry,
+        db_entry = entry,
         -- TODO seem to be needed
         name = 'name',
         value = 'value', -- TODO what to put value to, affects sorting?

--- a/lua/neoclip/telescope.lua
+++ b/lua/neoclip/telescope.lua
@@ -35,11 +35,11 @@ local function get_paste_handler(register_names, typ, op)
         -- TODO if we can know the bufnr "behind" telescope we wouldn't need to close
         -- and have it optional
         actions.close(prompt_bufnr)
+        handlers.paste(entry, op)
         if settings.on_paste.set_reg then
             handlers.set_registers(register_names, entry)
+            refresh_entry_if_needed(typ, entry.db_entry)
         end
-        handlers.paste(entry, op)
-        refresh_entry_if_needed(typ, entry.db_entry)
     end
 end
 
@@ -49,11 +49,11 @@ local function get_replay_recording_handler(register_names, typ)
         -- TODO if we can know the bufnr "behind" telescope we wouldn't need to close
         -- and have it optional
         actions.close(prompt_bufnr)
+        handlers.replay(entry)
         if settings.on_replay.set_reg then
             handlers.set_registers(register_names, entry)
+            refresh_entry_if_needed(typ, entry.db_entry)
         end
-        handlers.replay(entry)
-        refresh_entry_if_needed(typ, entry.db_entry)
     end
 end
 

--- a/lua/neoclip/telescope.lua
+++ b/lua/neoclip/telescope.lua
@@ -14,9 +14,15 @@ local settings = require('neoclip.settings').get()
 local utils = require('neoclip.utils')
 local picker_utils = require('neoclip.picker_utils')
 
-local function refresh_entry_if_needed (typ, entry)
+local function refresh_entry_if_needed (typ, telescope_entry)
     if settings.refresh_entry_on_select then
-        storage.set_as_most_recent(typ, entry)
+        storage.set_as_most_recent(
+            typ,
+            {
+                regtype = telescope_entry.regtype,
+                contents = telescope_entry.contents
+            }
+        )
     end
 end
 
@@ -25,7 +31,7 @@ local function get_set_register_handler(register_names, typ)
         local entry = action_state.get_selected_entry()
         actions.close(prompt_bufnr)
         handlers.set_registers(register_names, entry)
-        refresh_entry_if_needed(typ, entry.db_entry)
+        refresh_entry_if_needed(typ, entry)
     end
 end
 
@@ -38,7 +44,7 @@ local function get_paste_handler(register_names, typ, op)
         handlers.paste(entry, op)
         if settings.on_paste.set_reg then
             handlers.set_registers(register_names, entry)
-            refresh_entry_if_needed(typ, entry.db_entry)
+            refresh_entry_if_needed(typ, entry)
         end
     end
 end
@@ -52,7 +58,7 @@ local function get_replay_recording_handler(register_names, typ)
         handlers.replay(entry)
         if settings.on_replay.set_reg then
             handlers.set_registers(register_names, entry)
-            refresh_entry_if_needed(typ, entry.db_entry)
+            refresh_entry_if_needed(typ, entry)
         end
     end
 end
@@ -120,7 +126,6 @@ local function entry_maker(entry)
         regtype = entry.regtype,
         filetype = entry.filetype,
         ordinal = table.concat(entry.contents, '\n'),
-        db_entry = entry,
         -- TODO seem to be needed
         name = 'name',
         value = 'value', -- TODO what to put value to, affects sorting?

--- a/lua/neoclip/telescope.lua
+++ b/lua/neoclip/telescope.lua
@@ -16,7 +16,7 @@ local picker_utils = require('neoclip.picker_utils')
 
 local function refresh_entry_if_needed (typ, entry)
     if settings.refresh_entry_on_select then
-        storage.set_as_most_recent(entry, typ)
+        storage.set_as_most_recent(typ, entry)
     end
 end
 


### PR DESCRIPTION
Closes #85.

This is a feature I was also interested in, so I decided to try a simple implementation.

This will add a new boolean option `refresh_entry_on_select` (default = false), which when set, will make whichever entry the user selects on telescope/fzf as the most recent.

One thing I disliked about this is the name of the option `refresh_entry_on_select`. Do you have a better suggestion?

## Example:
Before selecting A:
![image](https://user-images.githubusercontent.com/26410371/210216505-31b20b1b-8bbe-4bb3-8ed5-4725174a75f2.png)

After selecting A, and reopening telescope:
![screenshot](https://user-images.githubusercontent.com/26410371/210216694-765ecc08-9480-4e9d-b0ac-d9826c9814b4.png)
