### PR TITLE
feat: allow to edit and entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ use {
             paste_behind = '<c-k>',
             replay = '<c-q>',  -- replay a macro
             delete = '<c-d>',  -- delete an entry
+            edit = '<c-e>',  -- edit an entry
             custom = {},
           },
           n = {
@@ -112,6 +113,7 @@ use {
             paste_behind = 'P',
             replay = 'q',
             delete = 'd',
+            edit = 'e',
             custom = {},
           },
         },
@@ -295,6 +297,9 @@ If you don't want to use the setting `continuous_sync`, but still keep two insta
 
 ### Remove entries
 You can remove entries manually using the keybinds for `delete`. You can also delete the whole history with `:lua require('neoclip').clear_history()`.
+
+### Edit entries
+You can edit the contents of an entry using the keybinds for `edit`. It'll open the contents of the entry in a separate floating buffer. When you leave the buffer (`:q`), it'll update the contents of the entry with what's in the buffer.
 
 ## Tips
 * Duplicate yanks are not stored, but rather pushed forward in the history such that they are the first choice when searching for previous yanks.

--- a/lua/neoclip/settings.lua
+++ b/lua/neoclip/settings.lua
@@ -31,6 +31,7 @@ local settings = {
                 paste_behind = '<c-k>',
                 replay = '<c-q>',
                 delete = '<c-d>',
+                edit = '<c-e>',
                 custom = {},
             },
             n = {
@@ -39,6 +40,7 @@ local settings = {
                 paste_behind = 'P',
                 replay = 'q',
                 delete = 'd',
+                edit = 'e',
                 custom = {},
             },
         },

--- a/lua/neoclip/sorted_set.lua
+++ b/lua/neoclip/sorted_set.lua
@@ -47,6 +47,26 @@ local insert = function(self, entry, opts)
     end
 end
 
+local replace = function(self, entry, new_entry)
+    local key = hash(entry)
+    local new_key = hash(new_entry)
+    local node = self.entries[key];
+
+    if not node then
+        error("Attempted to replace entry that doesn't exist", 2)
+    end
+
+    node.value = new_entry -- Replace entry in node.
+
+    -- Prevent duplicate entries
+    if self.entries[new_key] and key ~= new_key then
+        self:remove(new_entry)
+    end
+
+    self.entries[key] = nil
+    self.entries[new_key] = node
+end
+
 --- adds the entries from a plain table
 local update = function(self, entries)
     for _, entry in ipairs(entries) do
@@ -82,6 +102,7 @@ M.new = function(max_size)
         entries = {},
         -- methods
         insert = insert,
+        replace = replace,
         update = update,
         remove = remove,
         values = values,
@@ -89,5 +110,7 @@ M.new = function(max_size)
         clear = clear,
     }
 end
+
+M.hash = hash
 
 return M

--- a/lua/neoclip/storage.lua
+++ b/lua/neoclip/storage.lua
@@ -72,6 +72,11 @@ M.delete = function(typ, entry)
     post_change()
 end
 
+M.replace = function (typ, entry, newEntry)
+    storage[typ]:replace(entry, newEntry)
+    post_change()
+end
+
 M.push = function()
     require('neoclip.db').write(M.as_tbl())
 end

--- a/lua/neoclip/utils.lua
+++ b/lua/neoclip/utils.lua
@@ -11,4 +11,62 @@ M.join = function(t1, t2)
     return new_t
 end
 
+--- @param initial_lines string[]
+--- @param filetype string
+--- @param on_close fun(new_lines: string[]): nil
+M.open_editor_temp_window = function (initial_lines, filetype, on_close)
+    local temp_buffer = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(temp_buffer, 0, -1, false, initial_lines)
+    vim.api.nvim_buf_set_option(temp_buffer, 'filetype', filetype or '')
+    -- Requires a 'BufWriteCmd' or "FileWriteCmd" autocmd to write
+    vim.api.nvim_buf_set_option(temp_buffer, "buftype", "acwrite")
+    -- Allows the user to call :write
+    vim.api.nvim_buf_set_name(temp_buffer, "neoclip-temp")
+
+    local function make_ideal_win_config()
+        -- Default values are in case neovim is running in headless mode (e.g. during tests)
+        local stats = vim.api.nvim_list_uis()[1] or { width = 10, height = 10 }
+        local width = stats.width
+        local height = stats.height
+        local winWidth = math.ceil(width * 0.8)
+        local winHeight = math.ceil(height * 0.8)
+        return {
+            relative = "editor",
+            style = "minimal",
+            border = "single",
+            width = winWidth,
+            height = winHeight,
+            col = math.ceil((width - winWidth) / 2),
+            row = math.ceil((height - winHeight) / 2) - 1,
+        }
+    end
+
+    local win = vim.api.nvim_open_win(temp_buffer, true, make_ideal_win_config())
+
+    -- Makes sure the window stays at a proper size when vim is resized
+    vim.api.nvim_create_autocmd("VimResized", {
+        buffer = temp_buffer,
+        callback = function()
+            vim.api.nvim_win_set_config(win, make_ideal_win_config())
+        end,
+    })
+
+    -- "BufWriteCmd" and "FileWriteCmd" prevents the file from actually being written to a file
+    vim.api.nvim_create_autocmd({"BufWriteCmd", "FileWriteCmd"}, {
+        buffer = temp_buffer,
+        callback = function ()
+            vim.api.nvim_buf_set_option(temp_buffer, "modified", false)
+        end,
+    })
+
+    vim.api.nvim_create_autocmd({"WinClosed", "WinLeave"}, {
+        buffer = temp_buffer,
+        callback = function()
+            local lines = vim.api.nvim_buf_get_lines(temp_buffer, 0, -1, false)
+            vim.api.nvim_buf_delete(temp_buffer, { force = true })
+            on_close(lines)
+        end,
+    })
+end
+
 return M

--- a/tests/plenary/neoclip_spec.lua
+++ b/tests/plenary/neoclip_spec.lua
@@ -594,6 +594,7 @@ some line]],
                     paste_behind = '<c-c>',
                     replay = '<c-d>',
                     delete = '<c-e>',
+                    edit = '<c-e>',
                     custom = {
                         ['<c-f>'] = function(opts)
                             return opts
@@ -606,6 +607,7 @@ some line]],
                     paste_behind = 'c',
                     replay = 'd',
                     delete = 'e',
+                    edit = 'e',
                     custom = {
                         f = function(opts)
                             return opts
@@ -693,6 +695,70 @@ some line]],
                             filetype = "",
                             regtype = "l"
                         },
+                    },
+                    require('neoclip.storage').get().yanks
+                )
+            end,
+        }
+    end)
+    it("edit entry", function()
+        assert_scenario{
+            initial_buffer = [[This is some text
+This is also some text
+I like trains
+Foo Bar bar foo
+]],
+            feedkeys = {
+                -- Yank the four lines
+                "yy",
+                "j",
+                "yy",
+                "j",
+                "yy",
+                "j",
+                "yy",
+                -- Open telescope
+                {
+                    keys=[[:lua require('telescope').extensions.neoclip.neoclip()<CR>]],
+                    after = function()
+                        vim.wait(100, function() end)
+                    end,
+                },
+                "k", -- Select second entry (should be "I like trains")
+                "e", -- Edit the selected entry
+                "$ciw", -- Go to end of the line and change inner word
+                "aplanes", -- type "planes" in insert mode
+                ":q<CR>", -- quit
+                "<CR>", -- Select the entry
+            },
+            assert = function()
+                assert_equal_tables(
+                    {
+                        {
+                            contents = {"trains"},
+                            filetype = "",
+                            regtype = "c"
+                        },
+                        {
+                            contents = {"Foo Bar bar foo"},
+                            filetype = "",
+                            regtype = "l"
+                        },
+                        {
+                            contents = {"I like planes"},
+                            filetype = "",
+                            regtype = "l"
+                        },
+                        {
+                            contents = {"This is also some text"},
+                            filetype = "",
+                            regtype = "l"
+                        },
+                        {
+                            contents = {"This is some text"},
+                            filetype = "",
+                            regtype = "l"
+                        }
                     },
                     require('neoclip.storage').get().yanks
                 )

--- a/tests/plenary/sorted_set_spec.lua
+++ b/tests/plenary/sorted_set_spec.lua
@@ -12,6 +12,12 @@ local bar = {
     filetype = 'lua',
 }
 
+local baz = {
+    regtype = 'c',
+    contents = {'baz'},
+    filetype = 'lua',
+}
+
 local foo_python = {
     regtype = 'c',
     contents = {'foo'},
@@ -102,5 +108,57 @@ describe("storage", function()
         assert_equal_tables(s:values(), {})
         s:insert(foo)
         assert_equal_tables(s:values(), {foo})
+    end)
+    it("replace", function()
+        local s = ss.new()
+        s:insert(bar)
+
+        local a = {
+            regtype = 'c',
+            contents = {'a'},
+            filetype = 'lua',
+        }
+        local b = {
+            regtype = 'c',
+            contents = {'b'},
+            filetype = 'lua',
+        }
+        local c = {
+            regtype = 'c',
+            contents = {'c'},
+            filetype = 'lua',
+        }
+
+        -- Replace with one item
+        s:replace(bar, foo)
+        assert_equal_tables(s:values(), {foo})
+
+        s:insert(bar)
+        s:insert(baz)
+        assert_equal_tables(s:values(), {foo, bar, baz})
+
+        -- Replace at head
+        s:replace(foo, a)
+        assert_equal_tables(s:values(), {a, bar, baz})
+
+        -- Replace at tail
+        s:replace(baz, c)
+        assert_equal_tables(s:values(), {a, bar, c})
+
+        -- Replace at middle
+        s:replace(bar, b)
+        assert_equal_tables(s:values(), {a, b, c})
+
+        -- Replace item that was previously replaced
+        s:replace(b, bar)
+        assert_equal_tables(s:values(), {a, bar, c})
+
+        -- Replace item with entry that already exists
+        s:replace(c, a)
+        assert_equal_tables(s:values(), {bar, a})
+
+        -- Replace item with itself
+        s:replace(a, a)
+        assert_equal_tables(s:values(), {bar, a})
     end)
 end)


### PR DESCRIPTION
Closes #91.

This allows the user to edit an entry in telescope. To edit an entry, you have to open telescope, use the edit mapping (default <C-e> in insert mode), edit the new buffer however you want, then close the buffer (`:q`) to save the changes. Here are some screenshots:

- Open telescope: ![image](https://user-images.githubusercontent.com/26410371/212742692-9a52ca83-4f4f-43ce-aec0-a3379373f2fa.png)
- Press <C-e> in insert mode: ![image](https://user-images.githubusercontent.com/26410371/212742733-a0db01ce-66de-4330-9e61-8d1ac17bf648.png)
- Change the buffer contents: ![image](https://user-images.githubusercontent.com/26410371/212742796-625fcc9e-c541-4ccb-b890-71d2ed293696.png)
- Exit the new buffer (`:q`):  ![image](https://user-images.githubusercontent.com/26410371/212742855-6eb662d7-16de-4819-82ee-d14cc8a6ffd8.png)



