### PR TITLE
feat: closing telescope after action is now optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,14 +85,20 @@ use {
       content_spec_column = false,
       on_select = {
         move_to_front = false,
+        close_telescope = true,
       },
       on_paste = {
         set_reg = false,
         move_to_front = false,
+        close_telescope = true,
       },
       on_replay = {
         set_reg = false,
         move_to_front = false,
+        close_telescope = true,
+      },
+      on_custom_action = {
+        close_telescope = true,
       },
       keys = {
         telescope = {
@@ -154,13 +160,18 @@ use {
 * `content_spec_column`: Can be set to `true` (default `false`) to use instead of the preview.
   It will only show the type and number of lines next to the first line of the entry.
 * `on_select`:
-  * `move_to_front`: if the entry should be set as the lastest in the list when pressing the key to select a yank.
+  * `move_to_front`: if the entry should be set to last in the list when pressing the key to select a yank.
+  * `close_telescope`: if telescope should close whenever an item is selected.
 * `on_paste`:
   * `set_reg`: if the register should be populated when pressing the key to paste directly.
-  * `move_to_front`: if the entry should be set as the lastest in the list when pressing the key to paste directly.
+  * `move_to_front`: if the entry should be set to last in the list when pressing the key to paste directly.
+  * `close_telescope`: if telescope should close whenever a yank is pasted
 * `on_replay`:
   * `set_reg`: if the register should be populated when pressing the key to replay a recorded macro.
-  * `move_to_front`: if the entry should be set as the lastest in the list when pressing the key to replay a recorded macro.
+  * `move_to_front`: if the entry should be set to last in the list when pressing the key to replay a recorded macro.
+  * `close_telescope`: if telescope should close whenever a macro is replayed
+* `on_custom_action`:
+  * `close_telescope`: if telescope should close whenever a custom action is executed
 * `keys`: keys to use for the different pickers (`telescope` and `fzf-lua`).
   With `telescope` normal key-syntax is supported and both insert `i` and normal mode `n`.
   With `fzf-lua` only insert mode is supported and `fzf`-style key-syntax needs to be used.

--- a/lua/neoclip/settings.lua
+++ b/lua/neoclip/settings.lua
@@ -14,14 +14,20 @@ local settings = {
     content_spec_column = false,
     on_select = {
         move_to_front = false,
+        close_telescope = true,
     },
     on_paste = {
         set_reg = false,
         move_to_front = false,
+        close_telescope = true,
     },
     on_replay = {
         set_reg = false,
         move_to_front = false,
+        close_telescope = true,
+    },
+    on_custom_action = {
+        close_telescope = true,
     },
     keys = {
         telescope = {


### PR DESCRIPTION
This would resolve [this](https://github.com/AckslD/nvim-neoclip.lua/blob/6617f6cf8422be01eb5673e165ca20bc5c048085/lua/neoclip/telescope.lua#L61) and [this](https://github.com/AckslD/nvim-neoclip.lua/blob/6617f6cf8422be01eb5673e165ca20bc5c048085/lua/neoclip/telescope.lua#L77) todos.

It adds a new settings at `on_select`, `on_paste` and `on_replay` called `close_telescope` (defaults to true), which when set to true, will close telescope after the action. If set to false, the action will be executed while maintaining the telescope window open.