### PR TITLE
feat: display macros as map keycodes instead of raw bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ use {
       default_register_macros = 'q',
       enable_macro_history = true,
       content_spec_column = false,
+      disable_keycodes_parsing = false,
       on_select = {
         move_to_front = false,
         close_telescope = true,
@@ -158,6 +159,7 @@ use {
 * `default_register_macros`: What register to use for macros by default when not specified (e.g. `Telescope macroscope`).
 * `enable_macro_history`: If `true` (default) any recorded macro will be saved, see [macros](#macros).
 * `content_spec_column`: Can be set to `true` (default `false`) to use instead of the preview.
+* `disable_keycodes_parsing`: If set to `true` (default `false`), macroscope will display the internal byte representation, instead of a proper string that can be used in a `map`. So a macro like "`one<CR>two`" will be displayed as "`one\ntwo`"
   It will only show the type and number of lines next to the first line of the entry.
 * `on_select`:
   * `move_to_front`: if the entry should be set to last in the list when pressing the key to select a yank.

--- a/lua/neoclip/settings.lua
+++ b/lua/neoclip/settings.lua
@@ -12,6 +12,7 @@ local settings = {
     default_register_macros = 'q',
     enable_macro_history = true,
     content_spec_column = false,
+    disable_keycodes_parsing = false,
     on_select = {
         move_to_front = false,
         close_telescope = true,

--- a/tests/plenary/neoclip_spec.lua
+++ b/tests/plenary/neoclip_spec.lua
@@ -824,6 +824,33 @@ Ia
 Here]]
         }
     end)
+    it("transform macro to keycodes", function()
+        assert_scenario{
+            setup = function ()
+                require('neoclip').setup({ disable_keycodes_parsing = false })
+            end,
+            feedkeys = {
+                "qq", -- Start macro
+                "A<C-W>NEW<Esc>",
+                "q", -- Finish macro
+                { -- Open telescope for macro
+                    keys=[[:lua require('telescope').extensions.macroscope.macroscope()<CR>]],
+                    after = function()
+                        vim.wait(100, function() end)
+                    end,
+                },
+                "e", -- Open macro for edition
+                "yy", -- Yank the current macro text
+                ":q<CR>", -- Close edition window
+                "<ESC>", -- Close Telescope
+            },
+            assert = function ()
+                assert_equal_tables(require('neoclip.storage').get().yanks, {
+                    {regtype = "l", contents = {"A<C-W>NEW<Esc>" }, filetype = ""}
+                })
+            end,
+        }
+    end)
 end)
 
 -- TODO why does this needs it's own thing?


### PR DESCRIPTION
Closes #98.

Macros will now be shown as a proper string that can be used in a `map`,
instead of showing the raw byte representation of the keycodes.

An example: what would be previously shown as "one\ntwo" will now be
shown as "one<CR>two"

A new options `disable_keycodes_parsing` was added that if set to `true` (dafault `false`), will disable this feature, and revert to the old behavior

This option will only change how macros are displayed, and not how they are stored.

Here's a usage example:

- Here's a macro: ![image](https://user-images.githubusercontent.com/26410371/212791534-ae08c3ea-cbb0-48cc-b97b-5695a75ab532.png)

- Editing the macro (pressed `<C-E>`): ![image](https://user-images.githubusercontent.com/26410371/212791571-3ada49c1-3f41-4183-a8da-ba7f9d1b5f72.png)

- After editing the macro, but before closing the edit buffer: ![image](https://user-images.githubusercontent.com/26410371/212791663-130ada23-b509-4634-9448-367716fd2c35.png)

- After editing the macro: ![image](https://user-images.githubusercontent.com/26410371/212791687-45dcdb81-39f0-4d4d-82a1-a5964a2268ae.png)
- After replaying the macro (pressed `<C-Q>`): ![image](https://user-images.githubusercontent.com/26410371/212791978-6da17ed4-4a41-4691-9f9c-6334d262c72e.png)