### PR TITLE
fix: event without regcontents

### DIFF
--- a/lua/neoclip/handlers.lua
+++ b/lua/neoclip/handlers.lua
@@ -5,6 +5,9 @@ local storage = require('neoclip.storage')
 local settings = require('neoclip.settings').get()
 
 local function should_add(event)
+    if event.regcontents == nil then
+      return false
+    end
     if settings.length_limit then
         local length = #event.regcontents - 1
         for _,line in ipairs(event.regcontents) do


### PR DESCRIPTION
Fixes #109

Sadly regcontents don't exist when copying from nvim-tree the event is `vim.empty_dict()` so for now it's best to return from `should_add` to suppress the error. 

Before - yanking from nvim-tree:
![image](https://github.com/AckslD/nvim-neoclip.lua/assets/42934159/41925bee-0424-4b0c-a8a9-8d017d15e363)

After (no errors, value is added to register but not neoclip - which was like this all the time it's just not showing the annoying error that has to be acknowledged every time):
![image](https://github.com/AckslD/nvim-neoclip.lua/assets/42934159/0591a0fe-4a14-499b-9070-7da3f1246f2a)
