### PR TITLE
fix(fzf-lua): items are displayed as blank

### DIFF
--- a/lua/neoclip/fzf.lua
+++ b/lua/neoclip/fzf.lua
@@ -129,7 +129,7 @@ local function neoclip(register_names)
       actions = actions,
       fzf_opts = {
         ["--header"] = vim.fn.shellescape(picker_utils.make_prompt_title(register_names)),
-        ["--delimiter"] = [[\\.]],
+        ["--delimiter"] = [[\.]],
         -- comment `--nth` if you want to enable
         -- fuzzy matching the index number
         ["--with-nth"] = '2..',


### PR DESCRIPTION
The delemiter was set incorrectly and could not retrieve the content to display.