### PR TITLE
fix(fzf-lua): remove unnecessary shellescape in fzf_opts

### DIFF
--- a/lua/neoclip/fzf.lua
+++ b/lua/neoclip/fzf.lua
@@ -128,7 +128,7 @@ local function neoclip(register_names)
       previewer = Previewer,
       actions = actions,
       fzf_opts = {
-        ["--header"] = vim.fn.shellescape(picker_utils.make_prompt_title(register_names)),
+        ["--header"] = picker_utils.make_prompt_title(register_names),
         ["--delimiter"] = [[\.]],
         -- comment `--nth` if you want to enable
         -- fuzzy matching the index number


### PR DESCRIPTION
This commit fixes the following error message:

```
[Fzf-lua] `fzf_opts` are automatically shellescaped. Please remove surrounding quotes from --header='Pick new entry for registers "'
```

## Before
![before](https://github.com/user-attachments/assets/4807aacb-567f-40ec-a4fa-11d8589fe026)

## After
![after](https://github.com/user-attachments/assets/afa98cbf-8ede-4c1d-902f-41d604054b91)

This PR closes #136 