### PR TITLE
fix(fzf-lua): update update_scrollbar() to update_preview_scroolbar()

### DIFF
--- a/lua/neoclip/fzf.lua
+++ b/lua/neoclip/fzf.lua
@@ -99,7 +99,7 @@ function Previewer:populate_preview_buf(entry_str)
   vim.api.nvim_buf_set_lines(tmpbuf, 0, -1, false, entry.contents)
   vim.api.nvim_buf_set_option(tmpbuf, 'filetype', entry.filetype)
   self:set_preview_buf(tmpbuf)
-  self.win:update_scrollbar()
+  self.win:update_preview_scrollbar()
 end
 
 -- this function feeds elements into fzf


### PR DESCRIPTION
`FzfWin:update_scrollbar()` was changed to `FzfWin:update_preview_scroolbar()` in ibhagwan/fzf-lua@fc70792718d4a41101956c10ec04b6bf6a258777
It will make an error when using fzf-lua picker `:lua require('neoclip.fzf')()`
```
Error executing vim.schedule lua callback: ...cal/share/nvim/lazy/nvim-neoclip.lua/lua/neoclip/fzf.lua:102: attempt to call method 'update_scrollbar' (a nil value)
```