### PR TITLE
Add initial_mode to settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ require('neoclip').setup({
   enable_macro_history = true,
   content_spec_column = false,
   disable_keycodes_parsing = false,
+  initial_mode = 'insert',
   on_select = {
 	move_to_front = false,
 	close_telescope = true,
@@ -209,6 +210,7 @@ require('neoclip').setup({
 * `content_spec_column`: Can be set to `true` (default `false`) to use instead of the preview.
 * `disable_keycodes_parsing`: If set to `true` (default `false`), macroscope will display the internal byte representation, instead of a proper string that can be used in a `map`. So a macro like "`one<CR>two`" will be displayed as "`one\ntwo`"
   It will only show the type and number of lines next to the first line of the entry.
+* `initial_mode`: The mode in which to start the telescope picker, can be `insert` or `normal` (default `insert`).
 * `on_select`:
   * `move_to_front`: if the entry should be set to last in the list when pressing the key to select a yank.
   * `close_telescope`: if telescope should close whenever an item is selected.

--- a/lua/neoclip/settings.lua
+++ b/lua/neoclip/settings.lua
@@ -13,6 +13,7 @@ local settings = {
     enable_macro_history = true,
     content_spec_column = false,
     disable_keycodes_parsing = false,
+    initial_mode = 'insert',
     on_select = {
         move_to_front = false,
         close_telescope = true,

--- a/lua/neoclip/telescope.lua
+++ b/lua/neoclip/telescope.lua
@@ -286,6 +286,7 @@ local function get_export(register_names, typ)
 
         pickers.new(opts, {
             prompt_title = picker_utils.make_prompt_title(register_names),
+            initial_mode = settings.initial_mode,
             prompt_prefix = settings.prompt or nil,
             finder = finders.new_table({
                 results = results,


### PR DESCRIPTION
Add initial_mode to settings to control the prompt's initial mode.  Addresses #139  