### PR TITLE
Add dedent_picker_display setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ require('neoclip').setup({
   enable_macro_history = true,
   content_spec_column = false,
   disable_keycodes_parsing = false,
+  dedent_picker_display = false,
   on_select = {
 	move_to_front = false,
 	close_telescope = true,
@@ -209,6 +210,7 @@ require('neoclip').setup({
 * `content_spec_column`: Can be set to `true` (default `false`) to use instead of the preview.
 * `disable_keycodes_parsing`: If set to `true` (default `false`), macroscope will display the internal byte representation, instead of a proper string that can be used in a `map`. So a macro like "`one<CR>two`" will be displayed as "`one\ntwo`"
   It will only show the type and number of lines next to the first line of the entry.
+* `dedent_picker_display`: If `true` trim leading whitespace when displaying items in the picker (default `false`).
 * `on_select`:
   * `move_to_front`: if the entry should be set to last in the list when pressing the key to select a yank.
   * `close_telescope`: if telescope should close whenever an item is selected.

--- a/lua/neoclip/picker_utils.lua
+++ b/lua/neoclip/picker_utils.lua
@@ -4,4 +4,8 @@ M.make_prompt_title = function(register_names)
     return string.format("Pick new entry for registers %s", table.concat(register_names, ','))
 end
 
+M.dedent_picker_display = function(value)
+  return string.gsub(value, "^%s+", "")
+end
+
 return M

--- a/lua/neoclip/settings.lua
+++ b/lua/neoclip/settings.lua
@@ -13,6 +13,7 @@ local settings = {
     enable_macro_history = true,
     content_spec_column = false,
     disable_keycodes_parsing = false,
+    dedent_picker_display = false,
     on_select = {
         move_to_front = false,
         close_telescope = true,

--- a/lua/neoclip/telescope.lua
+++ b/lua/neoclip/telescope.lua
@@ -187,6 +187,11 @@ local function make_display(entry, typ)
     if settings.content_spec_column then
         table.insert(to_display, {spec_from_entry(entry), "Comment"})
     end
+
+    if settings.dedent_picker_display then
+      to_display[1] = picker_utils.dedent_picker_display(to_display[1])
+    end
+
     return displayer(to_display)
 end
 


### PR DESCRIPTION
See #117 

Adds a dedent_picker_display setting, which if true will cause the picker items to have leading whitespace trimmed.