### PR TITLE
Add picker_display_callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ require('neoclip').setup({
   enable_macro_history = true,
   content_spec_column = false,
   disable_keycodes_parsing = false,
+  picker_display_callback = nil,
   on_select = {
 	move_to_front = false,
 	close_telescope = true,
@@ -209,6 +210,7 @@ require('neoclip').setup({
 * `content_spec_column`: Can be set to `true` (default `false`) to use instead of the preview.
 * `disable_keycodes_parsing`: If set to `true` (default `false`), macroscope will display the internal byte representation, instead of a proper string that can be used in a `map`. So a macro like "`one<CR>two`" will be displayed as "`one\ntwo`"
   It will only show the type and number of lines next to the first line of the entry.
+* `picker_display_callback`: Function to call to customize the display of an item in the picker (default `nil`).
 * `on_select`:
   * `move_to_front`: if the entry should be set to last in the list when pressing the key to select a yank.
   * `close_telescope`: if telescope should close whenever an item is selected.

--- a/lua/neoclip/settings.lua
+++ b/lua/neoclip/settings.lua
@@ -13,6 +13,7 @@ local settings = {
     enable_macro_history = true,
     content_spec_column = false,
     disable_keycodes_parsing = false,
+    picker_display_callback = nil,
     on_select = {
         move_to_front = false,
         close_telescope = true,

--- a/lua/neoclip/telescope.lua
+++ b/lua/neoclip/telescope.lua
@@ -187,6 +187,11 @@ local function make_display(entry, typ)
     if settings.content_spec_column then
         table.insert(to_display, {spec_from_entry(entry), "Comment"})
     end
+
+    if settings.picker_display_callback then
+      to_display[1] = settings.picker_display_callback(to_display[1])
+    end
+
     return displayer(to_display)
 end
 


### PR DESCRIPTION
See #117.

Adds a setting for a picker_display_callback function, which if set will be run against items before displayed in the picker to allow the user to customize what gets shown.  Inspired by the use case of trimming leading whitespace but to give end user flexibility to make whatever updates they may wish.
