### PR TITLE
fix(fzf-lua): stackoverflow when git_icons=true

### DIFF
--- a/lua/neoclip/fzf.lua
+++ b/lua/neoclip/fzf.lua
@@ -125,6 +125,8 @@ local function neoclip(register_names)
     local actions = make_actions(register_names)
     require('fzf-lua').fzf_exec(fn, {
       prompt = settings.prompt or 'Prompt❯ ',
+      file_icons = false,
+      git_icons = false,
       previewer = Previewer,
       actions = actions,
       fzf_opts = {


### PR DESCRIPTION
Explicitly set `git_icons = false` and `file_icons = false`  to avoid StackOverflow.

Fixes https://github.com/AckslD/nvim-neoclip.lua/issues/143